### PR TITLE
Make From Git action local config agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pms init
 
 Help set up user and project configuration files if missing.
 
-### "to disk" or "save"
+### "to-disk" or "save"
 
 ```
 pms to-disk
@@ -107,25 +107,26 @@ Upload local collection and environment to Postman cloud.
 
 ### "from-git" or "load-remote"
 
-*With* a `pms.config` configuration in your directory, you can retrieve collection and environment files
-from a git `remote-repository` branch, and uploads to Postman cloud.
+*With* a `pms.config` configuration in your directory, retrieve collection
+and environment files from a git `remote-repository` branch, and upload
+them to Postman cloud.
 
 ```
 pms from-git
 pms load-remote
 ```
 
-*Without* a `pms.config` configuration in your directory, you can still retrieve collection and
-environment files from a git `remote-repository` branch, and uploads to Postman cloud by giving them as
-arguments.
+With or *without* a `pms.config` configuration in your directory, retrieve
+configuration, collection and environment files from an explicitly stated
+git remote branch given as arguments, and upload to Postman cloud.
 
 ```
 pms from-git git@somehost.com:repo/project.git
 pms load-remote git@somehost.com:repo/project.git main
 ```
 
-This is meant as a lightweight way to keep a collection up-to-date without using a local clone of the
-repository. You still need a `~/.pms`.
+This is meant as a lightweight way to keep a collection up-to-date without
+using a local clone of the repository. You still need a `~/.pms`.
 
 # Note about environment
 

--- a/README.md
+++ b/README.md
@@ -107,15 +107,25 @@ Upload local collection and environment to Postman cloud.
 
 ### "from-git" or "load-remote"
 
+*With* a `pms.config` configuration in your directory, you can retrieve collection and environment files
+from a git `remote-repository` branch, and uploads to Postman cloud.
+
 ```
 pms from-git
 pms load-remote
 ```
 
-Retrieve collection and environment files from a git `remote-repository`
-master branch, and uploads to Postman cloud. This is meant as a lightweight
-way to keep a collection up-to-date without using a local clone of the
-repository. You still need a `pms.config` configuration, and `~/.pms`.
+*Without* a `pms.config` configuration in your directory, you can still retrieve collection and
+environment files from a git `remote-repository` branch, and uploads to Postman cloud by giving them as
+arguments.
+
+```
+pms from-git git@somehost.com:repo/project.git
+pms load-remote git@somehost.com:repo/project.git main
+```
+
+This is meant as a lightweight way to keep a collection up-to-date without using a local clone of the
+repository. You still need a `~/.pms`.
 
 # Note about environment
 

--- a/pms
+++ b/pms
@@ -190,8 +190,6 @@ remoteGitArchive() {
 }
 
 toDisk() {
-  readProjectConfig
-
   if [ -n "$COLLECTION_NAME" ]; then
     saveCollection
   fi
@@ -201,8 +199,6 @@ toDisk() {
 }
 
 fromDisk() {
-  readProjectConfig
-
   if [ -n "$COLLECTION_NAME" ]; then
     loadCollection
   fi
@@ -245,8 +241,6 @@ fromGitRemoteConfig() {
 }
 
 fromGitLocalConfig() {
-  readProjectConfig
-
   if [ -z "$REMOTE_REPOSITORY" ]; then
     echo "No '${PROJECT_CONFIG_REMOTE_REPOSITORY}' configuration set."
     exit 2
@@ -315,8 +309,6 @@ initProjectProperty() {
 }
 
 init() {
-  readProjectConfig
-
   if [ ! -f "${USER_CONFIG_PATH}" ]; then
     echo "Creating user configuration file '${USER_CONFIG_PATH}'"
     touch "${USER_CONFIG_PATH}"
@@ -350,14 +342,28 @@ init() {
 
 #region RUN PROGRAM
 
-readUserConfig
-
 case "$action" in
   init) init ;;
-  from-disk) fromDisk ;;
-  to-disk) toDisk ;;
-  from-git-local-config) fromGitLocalConfig ;;
-  from-git-remote-config) fromGitRemoteConfig "$remoteName" "$remoteBranch" ;;
+
+  from-disk)
+    readUserConfig
+    readProjectConfig
+    fromDisk ;;
+
+  to-disk)
+    readUserConfig
+    readProjectConfig
+    toDisk ;;
+
+  from-git-local-config)
+    readUserConfig
+    readProjectConfig
+    fromGitLocalConfig ;;
+
+  from-git-remote-config)
+    readUserConfig
+    fromGitRemoteConfig "$remoteName" "$remoteBranch" ;;
+
   *) usage ;;
 esac
 

--- a/pms
+++ b/pms
@@ -30,10 +30,16 @@ usage() {
   echo ""
   echo "Project configuration file: $PROJECT_CONFIG_PATH"
   echo "User configuration file: $USER_CONFIG_PATH"
+  echo ""
+  echo "Example to load collecion from a git repository:"
+  echo -e "\t$0 from-git git@somehost.com:repo/project.git"
+  echo -e "\t$0 from-git git@somehost.com:repo/project.git master"
   exit 1
 }
 
 action=""
+remoteName=""
+remoteBranch=""
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     help)
@@ -45,7 +51,18 @@ while [[ "$#" -gt 0 ]]; do
     save | to-disk)
       action="to-disk" ;;
     load-remote | from-git)
-      action="from-git" ;;
+      if [ $# -eq 1 ]; then
+        action="from-git-local-config"
+      else
+        action="from-git-remote-config"
+        remoteName="$2"
+        if [ $# -ge 3 ]; then
+          remoteBranch="$3"
+          shift
+        fi
+        shift
+      fi
+      ;;
     --)
       break ;;
     *)
@@ -163,14 +180,18 @@ loadEnvironment() {
 }
 
 remoteGitArchive() {
-  echo "Retrieving from remote repository $REMOTE_REPOSITORY (branch $REMOTE_REPOSITORY_BRANCH)"
   local paths=("$@")
+  remote_repository="$1"
+  remote_repository_branch="$2"
+  local paths=("${@:3}")
   if [ ${#paths[@]} -gt 0 ]; then
-    git archive --remote="$REMOTE_REPOSITORY" "$REMOTE_REPOSITORY_BRANCH" "${paths[@]}" | tar -x
+    git archive --remote="$remote_repository" "$remote_repository_branch" "${paths[@]}" | tar -x
   fi
 }
 
 toDisk() {
+  readProjectConfig
+
   if [ -n "$COLLECTION_NAME" ]; then
     saveCollection
   fi
@@ -180,6 +201,8 @@ toDisk() {
 }
 
 fromDisk() {
+  readProjectConfig
+
   if [ -n "$COLLECTION_NAME" ]; then
     loadCollection
   fi
@@ -188,12 +211,46 @@ fromDisk() {
   fi
 }
 
-fromGit() {
+fromGitRemoteConfig() {
+  remote_repository="$1"
+  remote_repository_branch="${2:-master}"
+
+  if [ -z "$remote_repository" ]; then
+    echo "No remote repository set."
+    exit 2
+  fi
+
+  echo "Retrieving from remote repository $remote_repository:$remote_repository_branch"
+
+  pushd $(mktemp -d) >/dev/null
+
+  remoteGitArchive "$remote_repository" "$remote_repository_branch" "$PROJECT_CONFIG_PATH"
+  readProjectConfig
+
+  local paths=()
+  if [ "${COLLECTION_NAME}" ]; then
+    paths+=("${COLLECTION_FILE}")
+  fi
+  if [ "${ENVIRONMENT_NAME}" ]; then
+    paths+=("${ENVIRONMENT_FILE}")
+  fi
+  if [ ${#paths[@]} -eq 0 ]; then
+    echo "No collection or environment file to retrieve, skipping."
+    return 0
+  fi
+
+  remoteGitArchive "$remote_repository" "$remote_repository_branch" "${paths[@]}"
+  fromDisk
+  popd >/dev/null
+}
+
+fromGitLocalConfig() {
+  readProjectConfig
+
   if [ -z "$REMOTE_REPOSITORY" ]; then
     echo "No '${PROJECT_CONFIG_REMOTE_REPOSITORY}' configuration set."
     exit 2
   fi
-
   if [ -z "$REMOTE_REPOSITORY_BRANCH" ]; then
     echo "No '${PROJECT_CONFIG_REMOTE_REPOSITORY_BRANCH}' configuration set."
     exit 2
@@ -211,9 +268,8 @@ fromGit() {
     return 0
   fi
 
-  TMP_DIR=$(mktemp -d)
-  pushd "$TMP_DIR" >/dev/null
-  remoteGitArchive "${paths[@]}"
+  pushd $(mktemp -d) >/dev/null
+  remoteGitArchive "$REMOTE_REPOSITORY" "$REMOTE_REPOSITORY_BRANCH" "${paths[@]}"
   fromDisk
   popd >/dev/null
 }
@@ -259,6 +315,8 @@ initProjectProperty() {
 }
 
 init() {
+  readProjectConfig
+
   if [ ! -f "${USER_CONFIG_PATH}" ]; then
     echo "Creating user configuration file '${USER_CONFIG_PATH}'"
     touch "${USER_CONFIG_PATH}"
@@ -268,6 +326,7 @@ init() {
     echo "${USER_CONFIG_API_KEY}=${INIT_USER_API_KEY}" >> "${USER_CONFIG_PATH}"
     unset INIT_USER_API_KEY
   fi
+
   if [ ! -f "${PROJECT_CONFIG_PATH}" ]; then
     echo "Creating project configuration file '${PROJECT_CONFIG_PATH}'"
     initProjectProperty "${PROJECT_CONFIG_NAME}" "Enter name, used for collection and environment files names by default" "Name: "
@@ -292,13 +351,14 @@ init() {
 #region RUN PROGRAM
 
 readUserConfig
-readProjectConfig
 
 case "$action" in
   init) init ;;
   from-disk) fromDisk ;;
   to-disk) toDisk ;;
-  from-git) fromGit ;;
+  from-git-local-config) fromGitLocalConfig ;;
+  from-git-remote-config) fromGitRemoteConfig "$remoteName" "$remoteBranch" ;;
+  *) usage ;;
 esac
 
 #endregion

--- a/pms
+++ b/pms
@@ -31,7 +31,7 @@ usage() {
   echo "Project configuration file: $PROJECT_CONFIG_PATH"
   echo "User configuration file: $USER_CONFIG_PATH"
   echo ""
-  echo "Example to load collecion from a git repository:"
+  echo "Example to load collection from a git repository:"
   echo -e "\t$0 from-git git@somehost.com:repo/project.git"
   echo -e "\t$0 from-git git@somehost.com:repo/project.git master"
   exit 1


### PR DESCRIPTION
l'action "from-git git@repo" ne dépend plus d'un fichier de config local (sauf le global pour la clé API), mais va récupérer sur le repo git son fichier de config pour savoir quoi synchroniser.